### PR TITLE
benchmark results table generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ type RateLimiter interface {
 }
 ```
 
-The package also provides performance benchmarking; number of operations per number of concurrent goroutines. The following are results of `ratelimit.Benchmark` for different implementations with config aimed at `limit=100, period=10ms` executed on MacBook Pro Quad Core 16GB RAM: 
+The package also provides performance benchmarking; number of operations per number of concurrent goroutines. The following are results of `ratelimit.Benchmark` (in ns/op) for different implementations with config aimed at `limit=100, period=10ms` executed on MacBook Pro Quad Core 16GB RAM: 
 
-|Implementation | 1 | 4 | 16 | 64 | 256 | 1024 | 4096 | 16384 |
+| Implementation | 1 | 4 | 16 | 64 | 256 | 1024 | 4096 | 16384 |
 |---|--|--|--|--|--|--|--|--|
-|github.com/corver/ratelimit.NaiveWindow | 341 | 1_581 | 6_520 | 25_084 | 108_735 | 389_116 | 1_410_022 | 4_813_929 |
-|github.com/corver/ratelimit.SyncMapWindow | 609 | 2_056 | 14_259 | 53_523 | 222_216 | 756_072 | 1_969_951 | 3_686_225 |
+| github.com/corver/ratelimit.SyncMapWindow | 190 | 143 | 135 | 139 | 162 | 136 | 190 | 150 |
+| github.com/corver/ratelimit.NaiveWindow | 223 | 187 | 240 | 235 | 251 | 358 | 361 | 395 |
+| github.com/ellemouton/ratelimiter.TimerWindow | 59 | 63 | 81 | 111 | 116 | 122 | 121 | 121 |
+| github.com/ellemouton/ratelimiter.ChannelWindow | 189 | 192 | 206 | 216 | 287 | 310 | 326 | 340 |
 
 Please DM me link to your implementation for me to add your benchmark score.

--- a/bench.go
+++ b/bench.go
@@ -2,36 +2,29 @@ package ratelimit
 
 import (
 	"fmt"
-	"sync"
-	"sync/atomic"
+	"runtime"
 	"testing"
-	"time"
 )
 
 func Benchmark(b *testing.B, provider func() RateLimiter) {
 	// Run the benchmark for increasing number of concurrent goroutines.
 	for _, m := range []int{1, 4, 16, 64, 256, 1024, 4096, 16384} {
-		b.Run(fmt.Sprintf("Concurrency_%d", m), benchmark(provider, m))
+		BenchmarkFunc(provider, m)(b)
 	}
 }
 
-func benchmark(provider func() RateLimiter, m int) func(b *testing.B) {
+func BenchmarkFunc(provider func() RateLimiter, m int) func(b *testing.B){
+	// Run the benchmark for increasing number of concurrent goroutines.
 	return func(b *testing.B) {
-		limiter := provider()
-		var wg sync.WaitGroup
-		wg.Add(m)
-		var total int64
-		for i := 0; i < m; i++ {
-			go func(n int) {
-				t0 := time.Now()
-				for i := 0; i < n; i++ {
-					limiter.Request(fmt.Sprint(i))
+		cpus := runtime.GOMAXPROCS(0)
+		b.Run(fmt.Sprintf("Concurrency_%d", m), func(b *testing.B) {
+			limiter := provider()
+			b.SetParallelism(m/cpus)
+			b.RunParallel(func(b *testing.PB) {
+				for b.Next() {
+					limiter.Request("")
 				}
-				atomic.AddInt64(&total, time.Since(t0).Nanoseconds())
-				wg.Done()
-			}(b.N)
-		}
-		wg.Wait()
-		b.ReportMetric(float64(atomic.LoadInt64(&total))/float64(m*b.N), "ns/op")
+			})
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/corverroos/ratelimit
 
 go 1.15
 
-require github.com/stretchr/testify v1.6.1
+require (
+	github.com/ellemouton/ratelimiters v0.0.0-20201221190006-88f012abc67d
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
+github.com/corverroos/ratelimit v0.0.0-20201219121544-b1d97f10ad1c/go.mod h1:bETyVEPwSZFUsNkEvLPqmWnqDczNLOLyJktf9hA0S/A=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ellemouton/ratelimiters v0.0.0-20201221190006-88f012abc67d h1:uI0Hs9zu1MKEDNQ7SABKpbkZ/w6IY345jRZcDgeQy8Y=
+github.com/ellemouton/ratelimiters v0.0.0-20201221190006-88f012abc67d/go.mod h1:ttKvV90bCJIASAu3m1fmhc9CGbc6JcSAxKF7qQ39Xzo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/results_test.go
+++ b/results_test.go
@@ -1,0 +1,86 @@
+package ratelimit_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/corverroos/ratelimit"
+	em "github.com/ellemouton/ratelimiters"
+)
+
+type result struct {
+	goroutines int
+	nsop       int64
+}
+
+type results map[string][]result
+
+func TestGenResultsTable(t *testing.T) {
+	period := time.Millisecond
+	limit := 10
+
+	limiters := []struct{
+		name string
+		provider ratelimit.RateLimiter
+	}{
+		{
+			"github.com/corver/ratelimit.NaiveWindow",
+			ratelimit.NewNaiveWindow(period, limit),
+		},
+		{
+			"github.com/corver/ratelimit.SyncMapWindow",
+			ratelimit.NewSyncMapWindow(period, limit),
+		},
+		{
+			"github.com/ellemouton/ratelimiter.TimerWindow",
+			em.NewTimerWindow(period, limit),
+		},
+		{
+			"github.com/ellemouton/ratelimiter.ChannelWindow",
+			em.NewChannelWindow(period, limit),
+		},
+	}
+
+	res := make(results)
+
+	for _, limiter := range limiters {
+		for _, m := range []int{1, 4, 16, 64, 256, 1024, 4096, 16384} {
+			br := testing.Benchmark(ratelimit.BenchmarkFunc(func() ratelimit.RateLimiter {
+				return limiter.provider
+			}, m))
+
+			res[limiter.name] = append(res[limiter.name], result{
+				goroutines: m,
+				nsop:       br.NsPerOp(),
+			})
+		}
+	}
+
+	printResults(res)
+}
+
+func printResults(res results) error {
+	var impls []string
+	for k, _ := range res {
+		impls = append(impls, k)
+	}
+
+	heading := "| Implementation |"
+	table := "|---|"
+	for i := 0; i < len(res[impls[0]]); i++ {
+		heading += fmt.Sprintf(" %d |",res[impls[0]][i].goroutines)
+		table += "--|"
+	}
+
+	for k, v := range res {
+		table = table + "\n| "+k+" |"
+		for _, r := range v {
+			table += fmt.Sprintf(" %d |", r.nsop)
+		}
+	}
+
+	fmt.Println("Results shown in terms of ns/op")
+	fmt.Println(heading+"\n"+table)
+	return nil
+}


### PR DESCRIPTION
Sup! I come bearing a benchmark results table generator test. The test prints the markdown representation of the table to standard out and then you can just copy-pasta the results into the README.md.

Note, I separated out the 'Benchmark' function into 2 so that i could use the ```testing.Benchmark(f func(b testing.B))``` function which returns a nice ```testing.BenchmarkResults``` struct. Let me know if there is a nicer way that I should use instead.